### PR TITLE
CI: Dependabot에 github-actions 생태계 추가

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,11 @@ updates:
       interval: weekly
       time: '20:00'
     open-pull-requests-limit: 5
+  # GitHub Actions(워크플로에서 사용하는 액션) 버전을 자동 추적한다.
+  # 예: actions/checkout, actions/setup-node, peaceiris/actions-gh-pages 등
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+      time: '20:00'
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## 개요
워크플로에서 사용하는 GitHub Actions 버전을 Dependabot이 자동 추적하도록 `github-actions` 생태계를 추가합니다.

## 배경
PR #193 배포 로그에서 `actions/checkout@v4`, `actions/setup-node@v4`, `peaceiris/actions-gh-pages@v4` 가 Node.js 20 deprecation(2026-06-02부터 Node 24 강제) 경고를 띄웠습니다. 지금까지 액션 버전은 Dependabot 추적 대상이 아니었습니다.

## 변경
- `dependabot.yml`에 `github-actions` 생태계 추가(주간) → 액션 신버전 PR 자동 생성

## 동작
액션 업데이트도 기존 흐름을 그대로 탑니다: Dependabot PR → PR Build Check 검증 → patch/minor 자동 머지, major 수동 검토.

🤖 Generated with [Claude Code](https://claude.com/claude-code)