### PR TITLE
chore(deps): docsy 테마 버전을 v0.15.0으로 명시 고정

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/google/docsy-example
 
 go 1.12
+
+require github.com/google/docsy v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.15.0 h1:MNJ1nrE2ZuweXlUNaegTo/UbSKZJu+WMczahfZaxosI=
+github.com/google/docsy v0.15.0/go.mod h1:1Fj1W1O3esZh7IBQ8XAYtxtg10udBXuGI89+LUQc1AU=
+github.com/twbs/bootstrap v5.3.8+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
## 개요
현재 `go.mod`에 docsy require 라인이 없어 빌드가 매번 **latest**를 끌어오던 문제를 해결합니다. 동작·검증이 완료된 **v0.15.0**으로 direct require 고정합니다.

## 배경
- 이번 세션 초반(PR #193)에 docsy를 v0.13.0으로 고정하려 했으나, 이후 `go.mod`의 require 라인이 사라진 상태였습니다. 그 결과 `npx hugo` 빌드가 매번 latest(v0.15.0)를 resolve.
- UI/UX 업그레이드(PR #200)의 layout 오버라이드도 v0.15.0(Hugo 새 템플릿 시스템) 구조로 작성·검증되었으므로, 현재 동작 버전인 v0.15.0으로 고정하는 것이 가장 안전합니다.

## 변경
- `go.mod`: `require github.com/google/docsy v0.15.0` (direct)
- `go.sum`: 검증 해시 추가

## 검증
- 빌드 2회 연속 실행 시 go.mod가 v0.15.0으로 **고정 유지**(더 이상 latest로 올라가지 않음) 확인
- `npx hugo --minify` 무에러

## 이후
- docsy 버전 업데이트는 dependabot(gomod, PR #193에서 추가)이 자동 PR로 추적합니다. PR Build Check가 검증 후 patch/minor 자동 머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)