### PR TITLE
docs(supply-chain): SBOM Generator 페이지 간결화 및 취소선 버그 수정

### DIFF
--- a/content/en/guide/supply-chain/for-suppliers/skt-scanner/_index.md
+++ b/content/en/guide/supply-chain/for-suppliers/skt-scanner/_index.md
@@ -9,119 +9,62 @@ description: >
 
 ## SKT SBOM Generator
 
-The SKT SBOM Generator is an open source tool that lets suppliers generate
-deliverables that meet SK Telecom policy in a Docker environment.
+The SKT SBOM Generator is an open source tool that lets suppliers generate deliverables that meet SK Telecom policy in a Docker environment. You do not need to install per-language tools locally; it analyzes multiple languages and produces a CycloneDX (JSON) deliverable.
 
-- **Environment independence**: It runs on a Docker container, so there is no need to install Java, Python, etc. locally.
-- **Multi-language support**: It analyzes various languages such as Java, Python, Node.js, Go, Swift/iOS, and Android.
-- **Standard compliance**: It generates a CycloneDX (JSON) deliverable that meets SK Telecom policy.
+This page covers only the quick start. For installation, the full set of options, language-specific guides, input scenarios, the web UI, and other details, see the official repository documentation.
 
-> This page covers only the **quick start**. For installation, the full set of options, language-specific guides, input scenarios, the web UI, and other topics,
-> refer to the **official repository documentation** as the authoritative source.
->
 > [github.com/sktelecom/sbom-tools](https://github.com/sktelecom/sbom-tools)
 >
-> Bug reports, feature suggestions, and contributions via Pull Request are welcome.
+> Bug reports, feature suggestions, and Pull Request contributions are welcome.
 
-## Three Delivery Deliverables
+## Deliverables Generated
 
-A single run generates the following **three deliverables** together (the `--all` option).
+A single run generates the following three deliverables together (the `--all` option).
 
 | Deliverable | File | Purpose |
 |--------|------|------|
-| **SBOM** | `{project}_{version}_bom.json` | CycloneDX 1.6 component specification (the deliverable used as the delivery baseline) |
-| **Open Source Notice** | `{project}_{version}_NOTICE.{txt,html}` | Notice document for fulfilling license obligations |
-| **Open Source Risk Analysis Report** | `{project}_{version}_risk-report.{md,html}` | Aggregation of license and vulnerability risks (response deadlines: Critical 7 days, High 30 days) |
+| SBOM | `{project}_{version}_bom.json` | CycloneDX 1.6 component specification (the delivery baseline) |
+| Open Source Notice | `{project}_{version}_NOTICE.{txt,html}` | Notice document for fulfilling license obligations |
+| Open Source Risk Analysis Report | `{project}_{version}_risk-report.{md,html}` | Aggregation of license and vulnerability risks |
 
 ## Prerequisites
 
-The SBOM Generator runs on Docker. Install and run Docker Engine 20.10 or later. On Windows without Docker, we recommend Rancher Desktop, which is free. The first run downloads a scanner image (about 3–4 GB), so it takes roughly 5–15 minutes depending on your network.
+The SBOM Generator runs on Docker. Install and run Docker Engine 20.10 or later. On Windows without Docker, we recommend Rancher Desktop, which is free. The first run downloads a scanner image (about 3–4 GB), so it takes roughly 5–15 minutes.
 
 ## Getting Started on Windows (No Command Line)
 
-If you are not comfortable with the command line, you can generate an SBOM on Windows using only your mouse. Choose one of the two methods below; for full details, see the [Windows quick start guide](https://github.com/sktelecom/sbom-tools/blob/main/docs/notice-quickstart.md).
+If you are not comfortable with the command line, you can generate an SBOM in one of two ways. For the full procedure, see the [Windows quick start guide](https://github.com/sktelecom/sbom-tools/blob/main/docs/notice-quickstart.md).
 
-The simplest method is to download the executable and double-click it.
-
-1. Download `SBOM-Generator-*.exe` from the [latest release](https://github.com/sktelecom/sbom-tools/releases/latest).
-2. Double-click the downloaded file to run it.
-
-This executable is not yet code-signed, so Windows SmartScreen may show a protection warning when you run it. If it does, click "More info" and then select "Run anyway".
-
-Alternatively, you can download the whole repository and use it.
-
-1. From the repository's green `Code` button, choose `Download ZIP`, then unzip it.
-2. In the unzipped folder, double-click `scripts\sbom-ui.bat`.
-3. Once preparation is complete, the browser opens `http://localhost:8080` automatically.
-
-The generated deliverables are saved to the `C:\Users\[username]\sbom-output` folder.
+- Executable: Download `SBOM-Generator-*.exe` from the [latest release](https://github.com/sktelecom/sbom-tools/releases/latest) and double-click it. The file is not yet code-signed, so if Windows SmartScreen warns, click "More info" and then "Run anyway".
+- Repository ZIP: From the repository's `Code` button, choose `Download ZIP`, unzip it, and double-click `scripts\sbom-ui.bat`; the browser opens `http://localhost:8080`.
 
 ## Quick Start (CLI)
 
 On macOS and Linux, download and run the script from a shell.
 
 ```bash
-# 1) Download the script
 curl -O https://raw.githubusercontent.com/sktelecom/sbom-tools/main/scripts/scan-sbom.sh
 chmod +x scan-sbom.sh
-
-# 2) Generate the three deliverables from the source directory
 cd /path/to/my-project
 /path/to/scan-sbom.sh --project "MyApp" --version "1.0.0" --all --generate-only
 ```
 
-- Result: `MyApp_1.0.0_bom.json`, `MyApp_1.0.0_NOTICE.{txt,html}`, `MyApp_1.0.0_risk-report.{md,html}`
-- For other input forms—such as a GitHub URL, source ZIP, Docker image, existing SBOM, firmware, binary/RootFS—and
-  the full set of options, refer to the [Usage Guide](https://github.com/sktelecom/sbom-tools/blob/main/docs/usage-guide.md).
-- On Windows, run the same commands through `scripts\scan-sbom.bat`, which forwards them via Git Bash, so Git for Windows must be installed.
+- `--generate-only` creates files only locally, without uploading them to the portal (recommended until submission).
+- For the web UI, run `./scan-sbom.sh --ui` (the browser opens `http://localhost:8080`).
+- On Windows, run the same commands through `scripts\scan-sbom.bat` (it forwards them via Git Bash, so Git for Windows is required).
+- For other input forms such as a GitHub URL, source ZIP, Docker image, firmware, or binary, and the full set of options, see the [Usage Guide](https://github.com/sktelecom/sbom-tools/blob/main/docs/usage-guide.md).
 
-> `--generate-only` creates files only locally, without uploading them automatically to the portal. This is recommended until submission.
+## Learn More
 
-## Generate via the Web UI (if you are not comfortable with the CLI)
-
-If the command line feels daunting, you can use the browser-based web UI. Run it with a single line from the folder where you want to save the deliverables.
-
-```bash
-./scan-sbom.sh --ui     # http://localhost:8080 opens automatically
-```
-
-To run without the command line on Windows, see [Getting Started on Windows (No Command Line)](#getting-started-on-windows-no-command-line) above.
-
-On the screen, select the **scan target** (current folder / GitHub URL / ZIP / SBOM / firmware / Docker image),
-enter the project name and version, then run; the progress log is displayed in real time.
-
-![SBOM Generator web UI — scan target selection screen](web-ui.png)
-
-When complete, you can view or download the **SBOM, Notice, and Open Source Risk Analysis Report** on the screen.
-
-![SBOM Generator web UI — real-time log and deliverable download](web-ui-scan.png)
-
-> For details on each web UI input and descriptions of the deliverables, refer to the
-> [Notice, Security, and UI Guide](https://github.com/sktelecom/sbom-tools/blob/main/docs/notice-security-ui-guide.md).
-
-## Learn More (Official Repository Documentation)
-
-The authoritative source for using the tool is the repository documentation. Find the topic you need below.
+The authoritative source for using the tool is the repository documentation.
 
 | Topic | Document |
 |------|------|
-| Installation · First SBOM (including web UI) | [getting-started](https://github.com/sktelecom/sbom-tools/blob/main/docs/getting-started.md) |
-| Full options · By language · Analysis modes · CI/CD | [usage-guide](https://github.com/sktelecom/sbom-tools/blob/main/docs/usage-guide.md) |
+| Installation, first SBOM, web UI | [getting-started](https://github.com/sktelecom/sbom-tools/blob/main/docs/getting-started.md) |
+| Full options, by language, CI/CD | [usage-guide](https://github.com/sktelecom/sbom-tools/blob/main/docs/usage-guide.md) |
 | Scenarios by input form | [scenarios-guide](https://github.com/sktelecom/sbom-tools/blob/main/docs/scenarios-guide.md) |
-| Notice · Security · Web UI | [notice-security-ui-guide](https://github.com/sktelecom/sbom-tools/blob/main/docs/notice-security-ui-guide.md) |
-| Supplier SBOM analysis (`--analyze`) | [supplier-sbom-analysis](https://github.com/sktelecom/sbom-tools/blob/main/docs/supplier-sbom-analysis.md) |
+| Notice, security, web UI | [notice-security-ui-guide](https://github.com/sktelecom/sbom-tools/blob/main/docs/notice-security-ui-guide.md) |
 
 ## Next Steps
 
-After generating the SBOM file:
-
-1. Verify the file with the [Validation Checklist](../checklist/)
-2. Submit it to SK Telecom following the [Submission Process](../submission/)
-
-## Related Documents
-
-- [Submission Requirements](../requirements/): The required data fields that must be included in the SBOM
-- [Using Open Source Tools](../creation-guide/): For cases where you use open source tools such as cdxgen and Syft directly instead of the SKT tool
-- [Validation Checklist](../checklist/): Items to verify before submission
-- [Submission Process](../submission/): Submission method and email template
-</content>
+After generating the SBOM, verify the file with the [Validation Checklist](../checklist/) and submit it following the [Submission Process](../submission/). For the required data fields, see the [Submission Requirements](../requirements/); to use tools such as cdxgen or Syft directly instead of the SKT tool, see [Using Open Source Tools](../creation-guide/).

--- a/content/ko/guide/supply-chain/for-suppliers/skt-scanner/_index.md
+++ b/content/ko/guide/supply-chain/for-suppliers/skt-scanner/_index.md
@@ -9,118 +9,62 @@ description: >
 
 ## SKT SBOM Generator
 
-SKT SBOM Generator는 공급사가 Docker 환경에서
-SK텔레콤 정책에 부합하는 산출물을 생성할 수 있는 오픈소스 도구입니다.
+SKT SBOM Generator는 공급사가 Docker 환경에서 SK텔레콤 정책에 맞는 산출물을 생성할 수 있는 오픈소스 도구입니다. 로컬에 언어별 도구를 따로 설치하지 않아도 여러 언어를 분석해 CycloneDX(JSON) 산출물을 만듭니다.
 
-- **환경 독립성**: Docker 컨테이너 기반으로 동작하여 로컬에 Java, Python 등을 설치할 필요가 없습니다.
-- **다중 언어 지원**: Java, Python, Node.js, Go, Swift/iOS, Android 등 다양한 언어를 분석합니다.
-- **표준 준수**: SK텔레콤 정책에 맞는 CycloneDX (JSON) 산출물을 생성합니다.
+이 페이지는 빠른 시작만 다룹니다. 설치, 전체 옵션, 언어별 가이드, 입력 시나리오, 웹 UI 등 자세한 내용은 공식 저장소 문서를 참고하세요.
 
-> 이 페이지는 **빠른 시작**만 다룹니다. 설치, 전체 옵션, 언어별 가이드, 입력 시나리오, 웹 UI 등
-> **상세 사용법은 공식 저장소 문서**를 정본으로 참고하세요.
->
 > [github.com/sktelecom/sbom-tools](https://github.com/sktelecom/sbom-tools)
 >
-> 버그 제보, 기능 제안, Pull Request를 통한 기여를 환영합니다.
+> 버그 제보, 기능 제안, Pull Request 기여를 환영합니다.
 
-## 납품 산출물 3종
+## 생성되는 산출물
 
-한 번의 실행으로 다음 **3종 산출물**이 함께 생성됩니다(`--all` 옵션).
+한 번의 실행으로 다음 세 가지가 함께 생성됩니다(`--all` 옵션).
 
 | 산출물 | 파일 | 용도 |
 |--------|------|------|
-| **SBOM** | `{프로젝트}_{버전}_bom.json` | CycloneDX 1.6 구성요소 명세 (납품 기준 산출물) |
-| **오픈소스 고지문** | `{프로젝트}_{버전}_NOTICE.{txt,html}` | 라이선스 의무 이행을 위한 고지문 |
-| **오픈소스위험분석보고서** | `{프로젝트}_{버전}_risk-report.{md,html}` | 라이선스+취약점 위험 집계 (대응 기한: Critical 7일·High 30일) |
+| SBOM | `{프로젝트}_{버전}_bom.json` | CycloneDX 1.6 구성요소 명세 (납품 기준 산출물) |
+| 오픈소스 고지문 | `{프로젝트}_{버전}_NOTICE.{txt,html}` | 라이선스 의무 이행을 위한 고지문 |
+| 오픈소스위험분석보고서 | `{프로젝트}_{버전}_risk-report.{md,html}` | 라이선스와 취약점 위험 집계 |
 
 ## 사전 준비
 
-SBOM Generator는 Docker 위에서 동작합니다. Docker 엔진 20.10 이상을 설치하고 실행해 두세요. Docker가 설치되어 있지 않은 Windows에서는 무료로 쓸 수 있는 Rancher Desktop을 권장합니다. 첫 실행 때는 스캐너 이미지(약 3~4GB)를 내려받으므로 네트워크 상태에 따라 5~15분 정도 걸립니다.
+SBOM Generator는 Docker 위에서 동작합니다. Docker 엔진 20.10 이상을 설치하고 실행해 두세요. Docker가 없는 Windows에서는 무료인 Rancher Desktop을 권장합니다. 첫 실행 때 스캐너 이미지(약 3–4GB)를 내려받느라 5–15분쯤 걸립니다.
 
 ## Windows에서 명령줄 없이 시작
 
-명령줄이 익숙하지 않다면 Windows에서 마우스 조작만으로 SBOM을 생성할 수 있습니다. 아래 두 방법 중 하나를 고르면 되며, 자세한 설명은 [Windows 빠른 시작 문서](https://github.com/sktelecom/sbom-tools/blob/main/docs/notice-quickstart.md)를 참고하세요.
+명령줄이 익숙하지 않다면 두 가지 방법 중 하나로 SBOM을 생성할 수 있습니다. 자세한 절차는 [Windows 빠른 시작 문서](https://github.com/sktelecom/sbom-tools/blob/main/docs/notice-quickstart.md)를 참고하세요.
 
-가장 간단한 방법은 실행 파일을 내려받아 더블클릭하는 것입니다.
-
-1. [최신 릴리스](https://github.com/sktelecom/sbom-tools/releases/latest)에서 `SBOM-Generator-*.exe` 파일을 내려받습니다.
-2. 내려받은 파일을 더블클릭해 실행합니다.
-
-이 실행 파일은 아직 코드 서명이 되어 있지 않아, 실행할 때 Windows SmartScreen 보호 경고가 나타날 수 있습니다. 이때 "추가 정보"를 누른 뒤 "실행"을 선택하면 됩니다.
-
-실행 파일 대신 저장소를 통째로 내려받아 쓰는 방법도 있습니다.
-
-1. 저장소의 녹색 `Code` 버튼에서 `Download ZIP`을 눌러 내려받고 압축을 풉니다.
-2. 압축을 푼 폴더에서 `scripts\sbom-ui.bat`를 더블클릭합니다.
-3. 준비가 끝나면 브라우저에서 `http://localhost:8080`이 자동으로 열립니다.
-
-생성된 산출물은 `C:\Users\[사용자명]\sbom-output` 폴더에 저장됩니다.
+- 실행 파일: [최신 릴리스](https://github.com/sktelecom/sbom-tools/releases/latest)에서 `SBOM-Generator-*.exe`를 내려받아 더블클릭합니다. 이 파일은 아직 코드 서명이 되어 있지 않아 Windows SmartScreen 경고가 나타나면 "추가 정보"를 누른 뒤 "실행"을 선택합니다.
+- 저장소 ZIP: 저장소의 `Code` 버튼에서 `Download ZIP`을 받아 압축을 풀고 `scripts\sbom-ui.bat`를 더블클릭하면 브라우저에서 `http://localhost:8080`이 열립니다.
 
 ## 빠른 시작 (CLI)
 
 macOS와 Linux에서는 셸에서 스크립트를 내려받아 실행합니다.
 
 ```bash
-# 1) 스크립트 다운로드
 curl -O https://raw.githubusercontent.com/sktelecom/sbom-tools/main/scripts/scan-sbom.sh
 chmod +x scan-sbom.sh
-
-# 2) 소스 디렉터리에서 3종 산출물 생성
 cd /path/to/my-project
 /path/to/scan-sbom.sh --project "MyApp" --version "1.0.0" --all --generate-only
 ```
 
-- 결과: `MyApp_1.0.0_bom.json`, `MyApp_1.0.0_NOTICE.{txt,html}`, `MyApp_1.0.0_risk-report.{md,html}`
-- GitHub URL, 소스 ZIP, Docker 이미지, 기존 SBOM, 펌웨어, 바이너리/RootFS 등 다른 입력 형태와
-  전체 옵션은 [사용 가이드](https://github.com/sktelecom/sbom-tools/blob/main/docs/usage-guide.md)를 참고하세요.
-- Windows에서 명령줄을 쓰는 경우 같은 명령을 `scripts\scan-sbom.bat`로 실행합니다. 이 배치 파일은 내부적으로 Git Bash를 거치므로 Git for Windows가 설치되어 있어야 합니다.
+- `--generate-only`는 포털 업로드 없이 로컬에 파일만 생성합니다(제출 전까지 권장).
+- 웹 UI로 쓰려면 `./scan-sbom.sh --ui`를 실행합니다(브라우저에서 `http://localhost:8080`).
+- Windows에서 명령줄을 쓸 때는 같은 명령을 `scripts\scan-sbom.bat`로 실행합니다(Git Bash를 거치므로 Git for Windows 필요).
+- GitHub URL, 소스 ZIP, Docker 이미지, 펌웨어, 바이너리 등 다른 입력 형태와 전체 옵션은 [사용 가이드](https://github.com/sktelecom/sbom-tools/blob/main/docs/usage-guide.md)를 참고하세요.
 
-> `--generate-only`는 포털 자동 업로드 없이 로컬에 파일만 생성합니다. 제출 전까지 권장합니다.
+## 더 알아보기
 
-## 웹 UI로 생성 (CLI가 익숙하지 않은 경우)
-
-명령줄이 부담스럽다면 브라우저 기반 웹 UI를 사용할 수 있습니다. 산출물을 저장할 폴더에서 한 줄로 실행합니다.
-
-```bash
-./scan-sbom.sh --ui     # http://localhost:8080 자동 열림
-```
-
-Windows에서 명령줄 없이 실행하는 방법은 위의 [Windows에서 명령줄 없이 시작](#windows에서-명령줄-없이-시작)을 참고하세요.
-
-화면에서 **스캔 대상**(현재 폴더 / GitHub URL / ZIP / SBOM / 펌웨어 / Docker 이미지)을 선택하고
-프로젝트명·버전을 입력한 뒤 실행하면, 진행 로그가 실시간으로 표시됩니다.
-
-![SBOM Generator 웹 UI — 스캔 대상 선택 화면](web-ui.png)
-
-완료 후 **SBOM·고지문·오픈소스위험분석보고서**를 화면에서 보거나 내려받을 수 있습니다.
-
-![SBOM Generator 웹 UI — 실시간 로그와 산출물 다운로드](web-ui-scan.png)
-
-> 웹 UI의 입력별 상세와 산출물 설명은
-> [고지문·보안·UI 가이드](https://github.com/sktelecom/sbom-tools/blob/main/docs/notice-security-ui-guide.md)를 참고하세요.
-
-## 더 알아보기 (공식 저장소 문서)
-
-도구 사용법의 정본은 저장소 문서입니다. 아래에서 필요한 주제를 확인하세요.
+도구 사용법의 정본은 저장소 문서입니다.
 
 | 주제 | 문서 |
 |------|------|
-| 설치 · 첫 SBOM (웹 UI 포함) | [getting-started](https://github.com/sktelecom/sbom-tools/blob/main/docs/getting-started.md) |
-| 전체 옵션 · 언어별 · 분석 모드 · CI/CD | [usage-guide](https://github.com/sktelecom/sbom-tools/blob/main/docs/usage-guide.md) |
+| 설치, 첫 SBOM, 웹 UI | [getting-started](https://github.com/sktelecom/sbom-tools/blob/main/docs/getting-started.md) |
+| 전체 옵션, 언어별, CI/CD | [usage-guide](https://github.com/sktelecom/sbom-tools/blob/main/docs/usage-guide.md) |
 | 입력 형태별 시나리오 | [scenarios-guide](https://github.com/sktelecom/sbom-tools/blob/main/docs/scenarios-guide.md) |
-| 고지문 · 보안 · 웹 UI | [notice-security-ui-guide](https://github.com/sktelecom/sbom-tools/blob/main/docs/notice-security-ui-guide.md) |
-| 공급사 SBOM 분석 (`--analyze`) | [supplier-sbom-analysis](https://github.com/sktelecom/sbom-tools/blob/main/docs/supplier-sbom-analysis.md) |
+| 고지문, 보안, 웹 UI | [notice-security-ui-guide](https://github.com/sktelecom/sbom-tools/blob/main/docs/notice-security-ui-guide.md) |
 
 ## 다음 단계
 
-SBOM 파일 생성 완료 후:
-
-1. [검증 체크리스트](../checklist/)로 파일 확인
-2. [제출 절차](../submission/)에 따라 SK텔레콤에 제출
-
-## 관련 문서
-
-- [제출 요구사항](../requirements/): SBOM에 포함되어야 할 필수 데이터 필드
-- [오픈소스 도구 활용](../creation-guide/): SKT 도구 대신 cdxgen·Syft 등 오픈소스 도구를 직접 사용하는 경우
-- [검증 체크리스트](../checklist/): 제출 전 확인 사항
-- [제출 절차](../submission/): 제출 방법 및 이메일 양식
+SBOM을 생성한 뒤 [검증 체크리스트](../checklist/)로 파일을 확인하고 [제출 절차](../submission/)에 따라 제출합니다. 필수 데이터 필드는 [제출 요구사항](../requirements/), SKT 도구 대신 cdxgen, Syft 등을 직접 쓰는 방법은 [오픈소스 도구 활용](../creation-guide/)을 참고하세요.


### PR DESCRIPTION
## 배경

[SBOM Generator 페이지](https://sktelecom.github.io/guide/supply-chain/for-suppliers/skt-scanner/)에서 두 가지 문제를 수정합니다.

1. **렌더링 버그**: '약 3~4GB', '5~15분'의 물결표(`~`)가 마크다운 취소선 구문으로 해석돼, 두 물결표 사이 전체에 취소선이 그어졌습니다.
2. **길이**: 페이지가 전반적으로 너무 길었습니다.

## 변경 내용

- 물결표를 엔대시로 교체(`약 3–4GB`, `5–15분`)해 취소선 버그 해결
- 페이지를 빠른 시작과 핵심만 남기고 간결화(127줄 → 70줄, 약 45% 감소)
  - 웹 UI 전용 섹션과 스크린샷 2장, 중복 내비게이션('다음 단계'와 '관련 문서') 정리
  - 도입부 기능 나열을 한 문장으로 압축
  - 웹 UI 실행(`--ui`)은 빠른 시작 항목으로 통합
- 상세 사용법은 GitHub 저장소 문서를 참고하도록 안내를 강화
- 직전 PR에서 추가한 Windows 안내(`SBOM-Generator-*.exe`, `scripts\sbom-ui.bat`, `scan-sbom.bat`, Rancher Desktop 등)는 더 간결한 형태로 유지
- 한국어/영문 양쪽 동일 반영

## 검증

- 로컬 dev 서버 렌더 확인(HTTP 200), 취소선 태그 0개로 버그 해소 확인
- 한국어 문체 린트 통과(0건)