### PR TITLE
design: 본문·alert 박스의 80% 폭 제한 해제로 풀폭 통일

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -627,6 +627,33 @@ a.skt-card:hover,
    7. 본문(.td-content) — 측정폭·타이포 리듬·요소 디테일 (절제된 고급화)
       .td-content 는 홈(index)에 없으므로 본문 페이지에만 적용된다.
    =================================================================== */
+
+/* 본문 줄 길이 80% 제한 해제 — 아래 "본문 폭" 주석의 의도 완성.
+   Docsy td/_content.scss가 .td-content 직계 자식(문단·alert·목록 등)에
+   .td-max-width-on-larger-screens(lg 이상 max-width:80%)를 걸어 우측 공백이 생기므로,
+   같은 선택자 목록을 미러링해 동일 특이도로 뒤에서 덮는다.
+   (유틸리티 클래스 자체는 tabbed-pane 등 다른 쇼트코드가 쓰므로 건드리지 않는다) */
+@include media-breakpoint-up(lg) {
+  .td-content {
+    .footnotes,
+    > .alert,
+    > .highlight,
+    > .katex-display,
+    > .lead,
+    > .td-table,
+    > blockquote,
+    > dl dd,
+    > h1,
+    > h2,
+    > ol,
+    > p,
+    > pre,
+    > ul {
+      max-width: none;
+    }
+  }
+}
+
 .td-content {
   /* 본문 폭은 Docsy 컬럼(col-xl-8)이 제어 — 별도 max-width 제한 없음
      (제한 시 넓은 컬럼 안에서 우측 공백이 과도해짐) */


### PR DESCRIPTION
## 배경

문서 페이지에서 본문 문단과 alert 박스의 오른쪽이 일찍 끝나 `pageinfo` 박스와 폭이 어긋나 보입니다.

원인은 Docsy(v0.15.0)가 `.td-content` 직계 자식(`> p`, `> .alert`, `> ul` 등)에 큰 화면(lg 이상)에서 `max-width: 80%`를 적용하는 줄 길이 제한입니다(`td/_content.scss`). 기존 커스텀 SCSS 7번 절의 "본문 폭은 Docsy 컬럼이 제어 — 별도 max-width 제한 없음" 주석이 의도한 풀폭 설계가 이 기본 규칙에 가려져 있던 상태라, 이번 수정이 그 의도를 완성합니다.

## 변경

`assets/scss/_styles_project.scss`에 Docsy의 해당 선택자 목록을 미러링해 같은 특이도로 `max-width: none`을 덮습니다. 유틸리티 클래스(`.td-max-width-on-larger-screens`) 자체는 tabbed-pane 등 다른 쇼트코드가 쓰므로 건드리지 않았습니다. 폰트 크기는 변하지 않고 줄 길이만 본문 컬럼 폭에 맞게 늘어납니다.

OpenChain-KWG 사이트에 같은 수정을 먼저 적용해 검증했습니다(OpenChain-Project/OpenChain-KWG#303).

## 검증

- `hugo --minify` 빌드 성공.
- 컴파일된 CSS에서 오버라이드가 Docsy의 80% 규칙 뒤에 위치(동일 특이도, 캐스케이드로 적용)함을 확인.