### PR TITLE
design: 강조 박스 좌측 보더에 SK Red 액센트 도입

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -704,9 +704,9 @@ a.skt-card:hover,
     border-color: var(--skt-border);
   }
 
-  /* 인용 — 절제(2px 보더 + subtle 배경) */
+  /* 인용 — 좌측 SK Red 액센트 + subtle 배경 */
   blockquote {
-    border-left: 3px solid var(--skt-border-strong);
+    border-left: 3px solid var(--skt-accent);
     background: var(--skt-surface-subtle);
     color: var(--skt-text-muted);
     padding: .75rem 1.15rem;
@@ -778,7 +778,7 @@ a.skt-card:hover,
   padding: 1rem 1.25rem;
   background: var(--skt-surface-subtle);
   border: 1px solid var(--skt-border);
-  border-left: 3px solid var(--skt-border-strong);   /* 좌측 보더(기본 무채색) */
+  border-left: 3px solid var(--skt-accent);   /* 좌측 보더 = SK Red 액센트(다크 자동 보정) */
   border-radius: $border-radius-lg;
   color: var(--skt-text);
 }


### PR DESCRIPTION
## 배경

문서 강조 박스(기본 alert·blockquote)의 좌측 보더가 무채색이라 밋밋했고, SK Red(#EA002C) 브랜드 색은 홈 히어로 글로우에만 쓰이고 있었다. 강조 박스에만 SK Red 액센트를 도입해 브랜드 정체성을 살리되, Vercel 미니멀 기조는 유지한다.

## 변경

- 기본 `.alert`(info/primary)와 `.td-content blockquote`의 좌측 보더: 무채색 → `var(--skt-accent)`(SK Red)
- alert `warning`/`danger`/`success`는 기존 의미색(주황/빨강/초록) 유지
- 다크모드는 `#ff4d6a`로 자동 보정
- 배경·글자·버튼·링크·사이드바는 무채색 그대로

## 검증

- `npm run build` 정상
- 컴파일 CSS에서 alert·blockquote 좌측 보더 `var(--skt-accent)`, 라이트 #EA002C / 다크 #ff4d6a, 종류별 의미색 유지 확인