### PR TITLE
docs(supply-chain): link BomLens setup before scan-sbom.sh on the server page

### DIFF
--- a/content/en/guide/supply-chain/for-suppliers/server-delivery.md
+++ b/content/en/guide/supply-chain/for-suppliers/server-delivery.md
@@ -21,7 +21,7 @@ Treat the server as three layers, generate each one separately, then merge them.
 
 ## Generating each layer
 
-The commands below use BomLens (`scan-sbom.sh`). To use cdxgen/Syft directly, see [Using Open Source Tools](../creation-guide/).
+The commands below use BomLens's `scan-sbom.sh` script. For installing BomLens and its basics (downloading the script, the options, the web UI, and so on), see [BomLens](../skt-scanner/) first. To use cdxgen/Syft directly, see [Using Open Source Tools](../creation-guide/).
 
 ### OS layer
 

--- a/content/ko/guide/supply-chain/for-suppliers/server-delivery.md
+++ b/content/ko/guide/supply-chain/for-suppliers/server-delivery.md
@@ -21,7 +21,7 @@ description: >
 
 ## 층별 생성
 
-아래는 BomLens(`scan-sbom.sh`) 기준입니다. cdxgen·Syft를 직접 쓰는 경우는 [오픈소스 도구 활용](../creation-guide/)을 참고하세요.
+아래 명령은 BomLens의 실행 스크립트 `scan-sbom.sh`를 사용합니다. BomLens 설치와 기본 사용법(스크립트 내려받기, 옵션, 웹 UI 등)은 [BomLens](../skt-scanner/)를 먼저 참고하세요. cdxgen·Syft를 직접 쓰려면 [오픈소스 도구 활용](../creation-guide/)을 참고합니다.
 
 ### OS 층
 


### PR DESCRIPTION
서버 SBOM 페이지가 `scan-sbom.sh` 명령을 설치·맥락 안내 없이 전제해, skt-scanner를 거치지 않고 바로 진입하면 스크립트가 무엇인지 알 수 없었습니다. '층별 생성' 도입부에서 [BomLens](../skt-scanner/) 설치·기본 사용법을 먼저 참고하도록 보강했습니다(명령 자체는 정확하므로 유지). `hugo` 빌드 통과.