### PR TITLE
docs(supply-chain): restyle guide diagrams with grouped zones and a consistent SK palette

### DIFF
--- a/content/en/guide/supply-chain/for-suppliers/_index.md
+++ b/content/en/guide/supply-chain/for-suppliers/_index.md
@@ -38,6 +38,18 @@ flowchart TD
     H -->|Rejected| J[Remediate and Resubmit]
     J --> F
 
+    classDef start fill:#F2F2F2,stroke:#171717,color:#171717,stroke-width:1.5px
+    classDef proc fill:#ffffff,stroke:#c8c8c8,color:#171717,stroke-width:1px
+    classDef decision fill:#FFF3CD,stroke:#E0A800,color:#5A4100,stroke-width:1.5px
+    classDef good fill:#D9F0E4,stroke:#00A651,color:#0A5A32,stroke-width:1.5px
+    classDef danger fill:#FDE1E7,stroke:#EA002C,color:#8A0019,stroke-width:1.5px
+
+    class A start
+    class B,E,F,G proc
+    class C,H decision
+    class D,I good
+    class J danger
+
 ```
 
 

--- a/content/en/guide/supply-chain/for-suppliers/creation-guide/_index.md
+++ b/content/en/guide/supply-chain/for-suppliers/creation-guide/_index.md
@@ -13,20 +13,43 @@ description: >
 
 ```mermaid
 graph TD
-    A[Classify the supplied software] --> T1[Source code]
-    A --> T2[Executable/binary]
-    A --> T3[Firmware with no OS]
-    A --> T4[Container image]
-    A --> T5[Server]
-    A --> T6[Firmware with an embedded OS]
-    T1 --> M1[Scan the supplier's source code<br>cdxgen or BomLens]
-    T2 --> M1
-    T3 --> M1
-    T4 --> M2[App layer: scan source with cdxgen or BomLens<br>OS layer: scan the shipped image or rootfs with Syft or Trivy<br>merge the two layers]
-    T5 --> M2
-    T6 --> M2
-    M1 --> P[Submit the SBOM]
+    A{{"Classify the supplied software"}}
+
+    subgraph G1["Software delivery"]
+      direction LR
+      T1["Source code / app<br>(e.g., OSS/BSS, portals, middleware)"]
+      T2["Executable / library<br>(e.g., .jar, .dll, .so)"]
+      T3["Firmware with no OS<br>(e.g., bare-metal / RTOS devices)"]
+    end
+
+    subgraph G2["Delivery including an OS (e.g., Linux)"]
+      direction LR
+      T4["Container image<br>(e.g., CNF, containerized network function)"]
+      T5["Server / VM image<br>(e.g., VNF, server appliance)"]
+      T6["Firmware with an embedded OS<br>(e.g., base stations, routers, OLT/ONT, set-top boxes)"]
+    end
+
+    A --> G1
+    A --> G2
+    G1 --> M1(["Scan the source code<br>cdxgen or BomLens"])
+    G2 --> M2(["Scan source + OS image<br>cdxgen/BomLens + Syft/Trivy"])
+    M1 --> P(["Submit the SBOM"])
     M2 --> P
+
+    classDef start fill:#F2F2F2,stroke:#171717,color:#171717,stroke-width:1.5px
+    classDef typebox fill:#ffffff,stroke:#c8c8c8,color:#171717,stroke-width:1px
+    classDef source fill:#D9F0E4,stroke:#00A651,color:#0A5A32,stroke-width:1.5px
+    classDef osmerge fill:#EEDCF3,stroke:#68127A,color:#4A0D57,stroke-width:1.5px
+    classDef submit fill:#F2F2F2,stroke:#171717,color:#171717,stroke-width:1.5px
+
+    class A start
+    class T1,T2,T3,T4,T5,T6 typebox
+    class M1 source
+    class M2 osmerge
+    class P submit
+
+    style G1 fill:#F1FAF5,stroke:#00A651,stroke-width:1px,color:#0A5A32
+    style G2 fill:#FAF4FB,stroke:#68127A,stroke-width:1px,color:#4A0D57
 ```
 
 Regardless of the delivery form, the supplier scans the source code it developed to produce the SBOM. Even when you deliver an executable, a binary, or firmware, scan the source code that produced it, not the finished artifact. Scanning a finished binary directly yields no package manager metadata, so PURLs are omitted, vulnerability matching fails entirely, and the SBOM is rejected.

--- a/content/en/guide/supply-chain/overview/_index.md
+++ b/content/en/guide/supply-chain/overview/_index.md
@@ -20,8 +20,11 @@ graph LR
     C -->|Distribute| D[Customer A]
     C -->|Distribute| E[Customer B]
     C -->|Distribute| F[Customer C]
-    style B fill:#f9f,stroke:#333,stroke-width:2px
-    style C fill:#f96,stroke:#333,stroke-width:2px
+
+    classDef danger fill:#FDE1E7,stroke:#EA002C,color:#8A0019,stroke-width:1.5px
+    classDef victim fill:#ffffff,stroke:#c8c8c8,color:#171717,stroke-width:1px
+    class A,B,C danger
+    class D,E,F victim
 ```
 
 ## 2. Notable Attack Cases

--- a/content/en/guide/supply-chain/sbom/_index.md
+++ b/content/en/guide/supply-chain/sbom/_index.md
@@ -29,6 +29,16 @@ graph TD
     D --> E[Upload to Repository]
     E --> F[Vulnerability Analysis]
     F --> G[Security Remediation]
+
+    classDef start fill:#F2F2F2,stroke:#171717,color:#171717,stroke-width:1.5px
+    classDef proc fill:#ffffff,stroke:#c8c8c8,color:#171717,stroke-width:1px
+    classDef decision fill:#FFF3CD,stroke:#E0A800,color:#5A4100,stroke-width:1.5px
+    classDef good fill:#D9F0E4,stroke:#00A651,color:#0A5A32,stroke-width:1.5px
+
+    class A start
+    class B,E,F proc
+    class C decision
+    class D,G good
 ```
 
 ## SBOM Generation

--- a/content/en/guide/supply-chain/sbom/what-is-sbom.md
+++ b/content/en/guide/supply-chain/sbom/what-is-sbom.md
@@ -21,6 +21,16 @@ graph TD
     F --> G[Library D v1.0.0]
     F --> H[Library E v2.5.0]
     D --> F
+
+    classDef root fill:#F2F2F2,stroke:#171717,color:#171717,stroke-width:1.5px
+    classDef direct fill:#D9F0E4,stroke:#00A651,color:#0A5A32,stroke-width:1.5px
+    classDef trans fill:#EEDCF3,stroke:#68127A,color:#4A0D57,stroke-width:1.5px
+    classDef lib fill:#ffffff,stroke:#c8c8c8,color:#171717,stroke-width:1px
+
+    class A root
+    class B direct
+    class F trans
+    class C,D,E,G,H lib
 ```
 
 ## Key Components of an SBOM

--- a/content/ko/guide/supply-chain/for-suppliers/_index.md
+++ b/content/ko/guide/supply-chain/for-suppliers/_index.md
@@ -38,6 +38,18 @@ flowchart TD
     H -->|반려| J[보완 및 재제출]
     J --> F
 
+    classDef start fill:#F2F2F2,stroke:#171717,color:#171717,stroke-width:1.5px
+    classDef proc fill:#ffffff,stroke:#c8c8c8,color:#171717,stroke-width:1px
+    classDef decision fill:#FFF3CD,stroke:#E0A800,color:#5A4100,stroke-width:1.5px
+    classDef good fill:#D9F0E4,stroke:#00A651,color:#0A5A32,stroke-width:1.5px
+    classDef danger fill:#FDE1E7,stroke:#EA002C,color:#8A0019,stroke-width:1.5px
+
+    class A start
+    class B,E,F,G proc
+    class C,H decision
+    class D,I good
+    class J danger
+
 ```
 
 

--- a/content/ko/guide/supply-chain/for-suppliers/creation-guide/_index.md
+++ b/content/ko/guide/supply-chain/for-suppliers/creation-guide/_index.md
@@ -13,20 +13,43 @@ description: >
 
 ```mermaid
 graph TD
-    A[공급 소프트웨어 분류] --> T1[소스코드]
-    A --> T2[실행 파일/바이너리]
-    A --> T3[OS 없는 펌웨어]
-    A --> T4[컨테이너 이미지]
-    A --> T5[서버]
-    A --> T6[OS 내장 펌웨어]
-    T1 --> M1[공급사 소스코드 스캔<br>cdxgen 또는 BomLens]
-    T2 --> M1
-    T3 --> M1
-    T4 --> M2[앱 층: 소스코드 스캔 cdxgen 또는 BomLens<br>OS 층: 납품 이미지나 rootfs 스캔 Syft 또는 Trivy<br>두 층을 합쳐 제출]
-    T5 --> M2
-    T6 --> M2
-    M1 --> P[SBOM 제출]
+    A{{"공급 소프트웨어 분류"}}
+
+    subgraph G1["소프트웨어 공급"]
+      direction LR
+      T1["소스코드·앱<br>(예: OSS/BSS, 관리 포털, 미들웨어)"]
+      T2["실행 파일·라이브러리<br>(예: .jar, .dll, .so)"]
+      T3["OS 없는 펌웨어<br>(예: 베어메탈·RTOS 단말)"]
+    end
+
+    subgraph G2["OS(예: Linux) 포함 공급"]
+      direction LR
+      T4["컨테이너 이미지<br>(예: CNF, 컨테이너형 네트워크 기능)"]
+      T5["서버·VM 이미지<br>(예: VNF, 서버 어플라이언스)"]
+      T6["OS 내장 펌웨어<br>(예: 기지국, 라우터, OLT/ONT, 셋톱박스)"]
+    end
+
+    A --> G1
+    A --> G2
+    G1 --> M1(["소스코드 스캔<br>cdxgen 또는 BomLens"])
+    G2 --> M2(["소스코드 + OS 이미지 스캔<br>cdxgen/BomLens + Syft/Trivy"])
+    M1 --> P(["SBOM 제출"])
     M2 --> P
+
+    classDef start fill:#F2F2F2,stroke:#171717,color:#171717,stroke-width:1.5px
+    classDef typebox fill:#ffffff,stroke:#c8c8c8,color:#171717,stroke-width:1px
+    classDef source fill:#D9F0E4,stroke:#00A651,color:#0A5A32,stroke-width:1.5px
+    classDef osmerge fill:#EEDCF3,stroke:#68127A,color:#4A0D57,stroke-width:1.5px
+    classDef submit fill:#F2F2F2,stroke:#171717,color:#171717,stroke-width:1.5px
+
+    class A start
+    class T1,T2,T3,T4,T5,T6 typebox
+    class M1 source
+    class M2 osmerge
+    class P submit
+
+    style G1 fill:#F1FAF5,stroke:#00A651,stroke-width:1px,color:#0A5A32
+    style G2 fill:#FAF4FB,stroke:#68127A,stroke-width:1px,color:#4A0D57
 ```
 
 납품 형태와 무관하게, 공급사는 자기가 개발한 소스코드를 스캔해 SBOM을 만듭니다. 실행 파일이나 바이너리, 펌웨어로 납품하더라도 완성된 산출물이 아니라 그것을 만든 소스코드를 스캔합니다. 완성된 바이너리를 그대로 스캔하면 패키지 매니저 메타데이터가 없어 purl이 누락되고, 취약점 매칭이 전량 실패해 반려됩니다.

--- a/content/ko/guide/supply-chain/overview/_index.md
+++ b/content/ko/guide/supply-chain/overview/_index.md
@@ -20,8 +20,11 @@ graph LR
     C -->|배포| D[고객사 A]
     C -->|배포| E[고객사 B]
     C -->|배포| F[고객사 C]
-    style B fill:#f9f,stroke:#333,stroke-width:2px
-    style C fill:#f96,stroke:#333,stroke-width:2px
+
+    classDef danger fill:#FDE1E7,stroke:#EA002C,color:#8A0019,stroke-width:1.5px
+    classDef victim fill:#ffffff,stroke:#c8c8c8,color:#171717,stroke-width:1px
+    class A,B,C danger
+    class D,E,F victim
 ```
 
 ## 2. 주요 공격 사례

--- a/content/ko/guide/supply-chain/sbom/_index.md
+++ b/content/ko/guide/supply-chain/sbom/_index.md
@@ -29,6 +29,16 @@ graph TD
     D --> E[저장소 업로드]
     E --> F[취약점 분석]
     F --> G[보안 조치]
+
+    classDef start fill:#F2F2F2,stroke:#171717,color:#171717,stroke-width:1.5px
+    classDef proc fill:#ffffff,stroke:#c8c8c8,color:#171717,stroke-width:1px
+    classDef decision fill:#FFF3CD,stroke:#E0A800,color:#5A4100,stroke-width:1.5px
+    classDef good fill:#D9F0E4,stroke:#00A651,color:#0A5A32,stroke-width:1.5px
+
+    class A start
+    class B,E,F proc
+    class C decision
+    class D,G good
 ```
 
 ## SBOM 생성

--- a/content/ko/guide/supply-chain/sbom/what-is-sbom.md
+++ b/content/ko/guide/supply-chain/sbom/what-is-sbom.md
@@ -21,6 +21,16 @@ graph TD
     F --> G[라이브러리 D v1.0.0]
     F --> H[라이브러리 E v2.5.0]
     D --> F
+
+    classDef root fill:#F2F2F2,stroke:#171717,color:#171717,stroke-width:1.5px
+    classDef direct fill:#D9F0E4,stroke:#00A651,color:#0A5A32,stroke-width:1.5px
+    classDef trans fill:#EEDCF3,stroke:#68127A,color:#4A0D57,stroke-width:1.5px
+    classDef lib fill:#ffffff,stroke:#c8c8c8,color:#171717,stroke-width:1px
+
+    class A root
+    class B direct
+    class F trans
+    class C,D,E,G,H lib
 ```
 
 ## SBOM의 주요 구성 요소


### PR DESCRIPTION
공급망 보안 가이드의 mermaid 다이어그램 5종을 일관된 시각 언어로 다듬습니다.

- 도구 선택: 납품 형태를 두 그룹 존(소프트웨어 공급 / OS 포함 공급)으로 묶고, 각 유형에 통신 공급사가 알아볼 기능 예시((예: OSS/BSS, CNF, VNF, 기지국·라우터·셋톱박스 등)) 추가. 스캔 노드는 소스코드 스캔 / 소스코드 + OS 이미지 스캔으로 병렬화.
- 의존성 트리: 직접 의존성=그린, 전이 의존성=퍼플로 구분.
- 공급망 공격 흐름: 기존 mermaid 기본색(형광 분홍·주황)을 SK 레드 톤으로 교체, 감염 경로 강조.
- SBOM 제출 프로세스·라이프사이클: 판단=앰버, 시작·처리·완료 역할별 색.

전역 테마 대신 각 다이어그램 classDef로 밝은 채움+진한 글자+브랜드색 테두리를 명시해 라이트·다크 양쪽에서 읽히게 함. 한/영 동일 반영.