### PR TITLE
docs(supply-chain): put the supplier track first with a reader-split landing

### DIFF
--- a/content/en/guide/supply-chain/_index.md
+++ b/content/en/guide/supply-chain/_index.md
@@ -7,40 +7,29 @@ description: >
   An SBOM and vulnerability management guide for software supply chain security.
 ---
 
-## Software Supply Chain Security
+## Here to Submit an SBOM?
+
+If you are a supplier delivering software to SK Telecom, start right away with the [Supplier Guide](for-suppliers/). Submission takes four steps.
+
+1. Check the requirements in the [Supplier Guide](for-suppliers/).
+2. Generate the SBOM with [BomLens](for-suppliers/skt-scanner/) or [open source tools](for-suppliers/creation-guide/).
+3. Check it against the [Validation Checklist](for-suppliers/checklist/) before submitting.
+4. Submit it following the [Submission Process](for-suppliers/submission/).
+
+## New to Supply Chain Security?
 
 In recent years, alongside license compliance, security vulnerability management and software supply chain security have emerged as critical challenges in the open source ecosystem. As regulations tighten in the United States and Europe, SBOM (Software Bill of Materials) management and systematic vulnerability response have become essential.
 
-To strengthen the transparency and security of its software supply chain, SK Telecom has established a systematic management process and provides guidelines that both internal members and suppliers must comply with.
+To learn the background step by step, we recommend the following order.
 
-## Guide Structure
+1. [What Is Supply Chain Security?](overview/): Explains supply chain attack cases, why security matters, the global regulatory landscape, and SK Telecom's policy.
+2. [What Is an SBOM?](sbom/): Covers SBOM concepts and standards (SPDX, CycloneDX).
 
-### Supply Chain Security Overview
-
-Explains why supply chain security matters, the global regulatory landscape, and SK Telecom's supply chain security policy.
-
-### SBOM Management
-
-Provides a technical guide for both internal members and suppliers on what an SBOM is and how to generate and manage one.
-
-### Supplier Guide
-
-Provides SBOM submission requirements and a generation guide for suppliers that deliver software to SK Telecom.
-
-## Key Standards and Specifications
-
-* ISO/IEC 18974: OpenChain Security Assurance Specification
-* SPDX (ISO/IEC 5962): Software package data exchange standard
-* CycloneDX: Security-focused SBOM standard
-* NIST SSDF: Software supply chain security framework
-
-For related regulatory trends (U.S. EO 14028, the EU Cyber Resilience Act, etc.), see the [Regulatory Trends](/en/guide/supply-chain/overview/regulations/) page.
+Related standards such as ISO/IEC 18974 (OpenChain Security Assurance), SPDX (ISO/IEC 5962), CycloneDX (ECMA-424), and NIST SSDF, as well as regulatory trends such as U.S. EO 14028 and the EU Cyber Resilience Act, are introduced on the [Regulatory Trends](overview/regulations/) page.
 
 ## Contact
 
 If you have any questions regarding supply chain security, please refer to the following.
 
 * Supply chain security policy inquiries: [opensource@sktelecom.com](mailto:opensource@sktelecom.com)
-* SBOM submission: Contact your business unit and security team representatives (see [Submission Process](/en/guide/supply-chain/for-suppliers/submission/))
-</content>
-</invoke>
+* SBOM submission: Contact your business unit and security team representatives (see [Submission Process](for-suppliers/submission/))

--- a/content/en/guide/supply-chain/for-suppliers/_index.md
+++ b/content/en/guide/supply-chain/for-suppliers/_index.md
@@ -1,13 +1,21 @@
 ---
 title: "Supplier SBOM Submission Guide"
 linkTitle: "Supplier Guide"
-weight: 4
+weight: 1
 type: docs
 description: >
   An SBOM generation and submission guide for partner companies that supply software to SK Telecom.
 ---
 
 To strengthen the transparency and security of its software supply chain, SK Telecom asks suppliers to submit an SBOM (Software Bill of Materials) for all software components and dependencies they deliver. This guide explains how suppliers can generate and submit an SBOM in a format that meets SK Telecom's security policy.
+
+## Quick Start: Five Steps to Submission
+
+1. Check the accepted formats (CycloneDX JSON recommended) and required data fields in the [Submission Requirements](requirements/).
+2. Generate the SBOM with [BomLens](skt-scanner/). If you have your own build pipeline, use [open source tools](creation-guide/).
+3. If you deliver a server with an application on top of an OS, generate per layer and merge, following [Server SBOM](server-delivery/).
+4. Verify PURLs and transitive dependency coverage with the [Validation Checklist](checklist/).
+5. Name the file and submit it following the [Submission Process](submission/).
 
 ## Scope of Application
 

--- a/content/en/guide/supply-chain/overview/_index.md
+++ b/content/en/guide/supply-chain/overview/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Software Supply Chain Attacks and the Need for Security"
 linkTitle: "What Is Supply Chain Security?"
-weight: 1
+weight: 2
 type: docs
 description: >
   Introduces the importance of software supply chain security, recent threat trends, and the essential strategies for defending against them.

--- a/content/en/guide/supply-chain/sbom/_index.md
+++ b/content/en/guide/supply-chain/sbom/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "What Is an SBOM?"
 linkTitle: "What Is an SBOM?"
-weight: 2
+weight: 3
 type: docs
 description: >
   Guides developers and administrators through the full lifecycle of an SBOM, from its core concepts to generation, integration, and management.
@@ -9,17 +9,16 @@ description: >
 
 ## Overview
 
-This section is a practical SBOM (Software Bill of Materials) guide for members of the organization. Beyond simply complying with policy, it covers how to use SBOMs to improve the security of projects and the efficiency of dependency management.
+This section is a learning guide for those encountering an SBOM (Software Bill of Materials) for the first time. It covers what an SBOM is, why it is needed, and how the industry-standard formats differ from each other.
 
 ## Guide Structure
 
-This guide is organized step by step, from the adoption of SBOMs to their operation.
-
 1. [Concept and Necessity](what-is-sbom/): Explains what an SBOM is and the fundamental reasons why we need it now.
 2. [Standards Comparison (SPDX vs CycloneDX)](standards/): Understand the differences between the industry-standard formats so you can choose the format that fits the nature of your project.
-3. Generating a Project SBOM: Guides you through the practical methods for extracting an SBOM directly from a project under development.
-4. CI/CD Integration: Covers how to automate SBOM generation in CI/CD pipelines such as Jenkins and GitHub Actions.
-5. SBOM Management: Introduces strategies for storing generated SBOMs in a central repository and managing them by version.
+
+For the practical side — actually generating, validating, and submitting an SBOM — see the [Supplier Guide](../for-suppliers/).
+
+Below is the full lifecycle an SBOM flows through, from development to security remediation.
 
 ```mermaid
 graph TD
@@ -40,10 +39,3 @@ graph TD
     class C decision
     class D,G good
 ```
-
-## SBOM Generation
-
-For detailed SBOM generation methods and technical guidance, please refer to the following documents.
-
-- [Supplier Guide (For Suppliers)](../../for-suppliers/)
-- [How to Generate an SBOM](../../for-suppliers/creation-guide/)

--- a/content/ko/guide/supply-chain/_index.md
+++ b/content/ko/guide/supply-chain/_index.md
@@ -7,38 +7,29 @@ description: >
   소프트웨어 공급망 보안 관리를 위한 SBOM 및 취약점 관리 가이드
 ---
 
-## 소프트웨어 공급망 보안
+## SBOM을 제출하러 오셨나요?
+
+SK텔레콤에 소프트웨어를 납품하는 공급사라면 [공급사 가이드](for-suppliers/)에서 바로 시작하세요. 제출까지는 네 단계입니다.
+
+1. [공급사 가이드](for-suppliers/)에서 요구사항을 확인합니다.
+2. [BomLens](for-suppliers/skt-scanner/) 또는 [오픈소스 도구](for-suppliers/creation-guide/)로 SBOM을 생성합니다.
+3. [검증 체크리스트](for-suppliers/checklist/)로 제출 전에 점검합니다.
+4. [제출 절차](for-suppliers/submission/)에 따라 제출합니다.
+
+## 공급망 보안이 처음이라면
 
 최근 오픈소스 생태계에서는 라이선스 컴플라이언스와 함께 보안 취약점 관리와 소프트웨어 공급망 보안이 중요한 과제로 부상하였습니다. 미국과 유럽의 규제 강화에 따라 SBOM(Software Bill of Materials) 관리와 체계적인 취약점 대응이 필수가 되었습니다.
 
-SK텔레콤은 소프트웨어 공급망의 투명성과 보안성을 강화하기 위해 체계적인 관리 프로세스를 수립하고, 내부 구성원과 공급사 모두가 준수해야 할 가이드라인을 제공합니다.
+배경부터 차근차근 배우려면 다음 순서를 권합니다.
 
-## 가이드 구성
+1. [공급망 보안이란?](overview/): 공급망 공격 사례와 보안의 필요성, 글로벌 규제 동향, SK텔레콤의 정책을 설명합니다.
+2. [SBOM 이란?](sbom/): SBOM의 개념과 표준(SPDX, CycloneDX)을 다룹니다.
 
-### 공급망 보안 개요
-
-공급망 보안이 왜 중요한지, 글로벌 규제 동향은 어떠한지, 그리고 SK텔레콤의 공급망 보안 정책을 설명합니다.
-
-### SBOM 관리
-
-SBOM이란 무엇이며, 어떻게 생성하고 관리하는지에 대한 내부 구성원 및 공급사 모두를 위한 기술 가이드를 제공합니다.
-
-### 공급사 가이드
-
-SK텔레콤에 소프트웨어를 납품하는 공급사를 위한 SBOM 제출 요구사항 및 생성 가이드를 제공합니다.
-
-## 주요 표준 및 규격
-
-* ISO/IEC 18974: OpenChain Security Assurance 규격
-* SPDX (ISO/IEC 5962): 소프트웨어 패키지 데이터 교환 표준
-* CycloneDX: 보안 중심의 SBOM 표준
-* NIST SSDF: 소프트웨어 공급망 보안 프레임워크
-
-관련 규제 동향(미국 EO 14028, EU Cyber Resilience Act 등)은 [규제 동향](/guide/supply-chain/overview/regulations/) 페이지를 참고하세요.
+ISO/IEC 18974(OpenChain Security Assurance), SPDX(ISO/IEC 5962), CycloneDX(ECMA-424), NIST SSDF 등 관련 표준과 미국 EO 14028, EU Cyber Resilience Act 등 규제 동향은 [규제 동향](overview/regulations/) 페이지에서 소개합니다.
 
 ## 문의
 
 공급망 보안과 관련하여 문의사항이 있으시면 아래를 참고하세요.
 
 * 공급망 보안 정책 문의: [opensource@sktelecom.com](mailto:opensource@sktelecom.com)
-* SBOM 제출: 사업부서 및 보안부서 담당자에게 문의 ([제출 절차](/guide/supply-chain/for-suppliers/submission/) 참고)
+* SBOM 제출: 사업부서 및 보안부서 담당자에게 문의 ([제출 절차](for-suppliers/submission/) 참고)

--- a/content/ko/guide/supply-chain/for-suppliers/_index.md
+++ b/content/ko/guide/supply-chain/for-suppliers/_index.md
@@ -1,13 +1,21 @@
 ---
 title: "공급사 SBOM 제출 가이드"
 linkTitle: "공급사 가이드"
-weight: 4
+weight: 1
 type: docs
 description: >
   SK텔레콤에 소프트웨어를 공급하는 파트너사를 위한 SBOM 생성 및 제출 가이드입니다.
 ---
 
 SK텔레콤은 소프트웨어 공급망의 투명성과 보안성을 강화하기 위해, 공급사로부터 납품받는 모든 소프트웨어 구성 요소 및 의존성에 대한 SBOM(Software Bill of Materials) 제출을 요청드리고 있습니다. 본 가이드는 공급사가 SK텔레콤의 보안 정책에 맞는 형식으로 SBOM을 생성하고 제출하는 방법을 안내합니다.
+
+## 빠른 시작: 제출까지 5단계
+
+1. [제출 요구사항](requirements/)에서 허용 포맷(CycloneDX JSON 권장)과 필수 데이터 필드를 확인합니다.
+2. [BomLens](skt-scanner/)로 SBOM을 생성합니다. 자체 빌드 파이프라인이 있다면 [오픈소스 도구](creation-guide/)를 활용합니다.
+3. OS 위에 애플리케이션을 얹어 납품하는 서버라면 [서버 SBOM 생성](server-delivery/)에 따라 층별로 생성해 합칩니다.
+4. [검증 체크리스트](checklist/)로 PURL과 전이 의존성 포함 여부를 점검합니다.
+5. [제출 절차](submission/)에 따라 파일명을 정하고 제출합니다.
 
 ## 적용 대상
 

--- a/content/ko/guide/supply-chain/overview/_index.md
+++ b/content/ko/guide/supply-chain/overview/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "소프트웨어 공급망 공격과 보안 필요성"
 linkTitle: "공급망 보안이란?"
-weight: 1
+weight: 2
 type: docs
 description: >
   소프트웨어 공급망 보안의 중요성과 최근 위협 동향, 그리고 이를 방어하기 위한 필수 전략을 소개합니다.

--- a/content/ko/guide/supply-chain/sbom/_index.md
+++ b/content/ko/guide/supply-chain/sbom/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "SBOM 이란?"
 linkTitle: "SBOM 이란?"
-weight: 2
+weight: 3
 type: docs
 description: >
   개발자와 관리자가 알아야 할 SBOM의 핵심 개념부터 생성, 통합, 관리까지의 전체 라이프사이클을 안내합니다.
@@ -9,17 +9,16 @@ description: >
 
 ## 개요
 
-이 섹션은 기업 구성원을 위한 SBOM(Software Bill of Materials) 실무 가이드입니다. 단순히 정책을 준수하는 것을 넘어, SBOM을 활용하여 프로젝트의 보안성을 높이고 의존성 관리의 효율성을 높이는 방법을 다룹니다.
+이 섹션은 SBOM(Software Bill of Materials)을 처음 접하는 분들을 위한 학습 가이드입니다. SBOM이 무엇이고 왜 필요한지, 업계 표준 포맷은 서로 무엇이 다른지를 다룹니다.
 
 ## 가이드 구성
 
-본 가이드는 SBOM의 도입부터 운영까지 단계별로 구성되어 있습니다.
-
 1. [개념 및 필요성](what-is-sbom/): SBOM이 무엇이며, 왜 지금 우리에게 필요한지 근본적인 이유를 설명합니다.
 2. [표준 비교 (SPDX vs CycloneDX)](standards/): 업계 표준 포맷의 차이점을 이해하고, 프로젝트 성격에 맞는 포맷을 선택할 수 있습니다.
-3. 프로젝트 SBOM 생성: 개발 중인 프로젝트에서 직접 SBOM을 추출하는 실무적인 방법을 안내합니다.
-4. CI/CD 통합: Jenkins, GitHub Actions 등 CI/CD 파이프라인에 SBOM 생성을 자동화하는 방법을 다룹니다.
-5. SBOM 관리: 생성된 SBOM을 중앙 저장소에 저장하고 버전별로 관리하는 전략을 소개합니다.
+
+SBOM을 실제로 생성하고 검증해 제출하는 실무 방법은 [공급사 가이드](../for-suppliers/)에서 다룹니다.
+
+아래는 개발부터 보안 조치까지 SBOM이 흐르는 전체 라이프사이클입니다.
 
 ```mermaid
 graph TD
@@ -40,10 +39,3 @@ graph TD
     class C decision
     class D,G good
 ```
-
-## SBOM 생성
-
-상세한 SBOM 생성 방법과 기술적 가이드는 다음 문서를 참고하시기 바랍니다.
-
-- [공급사 가이드 (For Suppliers)](../../for-suppliers/)
-- [SBOM 생성 방법](../../for-suppliers/creation-guide/)


### PR DESCRIPTION
공급망 보안 가이드 개선 1단계: 실무자 진입 병목 해소.

- 섹션 순서 재배치: 공급사 가이드를 메뉴 맨 앞으로 (for-suppliers=1, overview=2, sbom=3, weight 공백 제거)
- 루트 랜딩을 독자 분기로 재작성: 상단 'SBOM을 제출하러 오셨나요?' 4단계 최단 경로, 하단 학습 트랙 안내
- 공급사 가이드 홈에 '빠른 시작: 제출까지 5단계' 추가
- SBOM 이란? 섹션의 죽은 로드맵(5단계 중 3개가 없는 페이지) 축소, 잘못된 링크 깊이(../../) 제거, '기업 구성원을 위한' 문구를 학습 트랙 표현으로 정리

내부 감사와 외부 벤치마크(OpenChain Telco, CISA/NTIA, Anchore) 조사에 근거한 개선 시리즈의 첫 PR. 한/영 동일 반영.