### PR TITLE
style: color body links SK Red instead of underlining them

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -743,13 +743,16 @@ a.skt-card:hover,
   .skt-table tbody tr { transition: background var(--skt-transition); }
   .skt-table tbody tr:hover > * { background: var(--skt-surface-subtle); }
 
-  /* 본문 링크 — 읽는 중 식별 위해 옅은 밑줄 (표 셀 안 링크 포함) */
+  /* 본문 링크 — SK Red 글자색으로 식별, 밑줄은 hover에서만 (표 셀 안 링크 포함) */
   p a, li a, td a, th a {
+    color: var(--skt-accent);
+    text-decoration: none;
+  }
+  p a:hover, li a:hover, td a:hover, th a:hover {
+    color: var(--skt-accent);
     text-decoration: underline;
-    text-decoration-color: var(--skt-border-strong);
     text-underline-offset: .15em;
   }
-  p a:hover, li a:hover, td a:hover, th a:hover { text-decoration-color: currentColor; }
 
   /* hr / 이미지 */
   hr {
@@ -796,8 +799,8 @@ a.skt-card:hover,
 .alert p { margin-bottom: .5rem; color: var(--skt-text-muted); }
 .alert ul, .alert ol { margin-bottom: 0; padding-left: 1.15rem; color: var(--skt-text-muted); }
 .alert > :last-child { margin-bottom: 0; }
-.alert a { color: var(--skt-text); text-decoration: underline; text-decoration-color: var(--skt-border-strong); text-underline-offset: .15em; }
-.alert a:hover { text-decoration-color: currentColor; }
+.alert a { color: var(--skt-accent); text-decoration: none; }
+.alert a:hover { color: var(--skt-accent); text-decoration: underline; text-underline-offset: .15em; }
 [data-bs-theme='dark'] .alert {
   background: var(--skt-surface-muted);
   border-color: var(--skt-border-strong);


### PR DESCRIPTION
본문 링크(문단, 목록, 표 셀, 알림 박스)의 식별 방식을 옅은 회색 밑줄에서 SK Red(#EA002C) 글자색으로 바꿉니다. 밑줄은 hover 시에만 나타납니다.

- 기존 옅은 밑줄이 눈에 잘 띄지 않는다는 피드백 반영. 글로벌 문서 사이트(Google 개발자 문서 등)와 같은 색 기반 링크 패턴
- 다크모드는 기존 보정색(#ff4d6a)이 --skt-accent 변수로 자동 적용
- 접근성: 흰 배경 대비 4.65:1(WCAG AA), 본문 텍스트와의 구분 3.6:1(3:1 기준), hover 밑줄로 색 외 단서 제공
- 사이드바와 네비게이션 링크는 기존대로 유지