### PR TITLE
style(section-index): make subpage title larger than its description

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -769,6 +769,19 @@ a.skt-card:hover,
   }
 }
 
+/* 하위페이지 목록(Docsy section-index) — 제목이 h5(전역 14px)라 설명 p(16px)보다
+   작아지는 위계 역전을 보정. 제목을 설명보다 크게(18px) 올리고 간격을 정리한다. */
+.section-index .entry {
+  h5 {
+    font-size: 1.125rem;
+    line-height: 1.35;
+  }
+  p {
+    color: var(--skt-text-muted);
+    line-height: 1.6;
+  }
+}
+
 /* 커스텀 섹션 페이지(프로젝트·컴플라이언스 목록) — 고정 navbar 높이만큼 상단 오프셋 */
 .skt-section-page {
   padding-top: 5.5rem;


### PR DESCRIPTION
## 문제
가이드 섹션 하단 하위페이지 목록에서 제목이 설명 텍스트보다 작게 보임.

## 원인
Docsy `section-index` 파셜은 하위페이지 제목을 `<h5>`로 렌더한다. 이 사이트는 KWG(devsite) 스케일에 맞춰 `$h5-font-size`를 0.875rem(14px)으로 낮춰 뒀는데, 설명 `<p>`는 본문 기본 16px이라 제목(14px) < 설명(16px)으로 위계가 뒤집혔다.

## 조치
전역 h5 대신 `.section-index .entry`로 스코프해 제목을 1.125rem(18px)로 올리고, 설명은 muted 색으로 낮춰 대비를 명확히 했다. 모든 섹션 인덱스 페이지에 공통 적용된다.