### PR TITLE
docs(supply-chain): revert tool selection diagram to the original layout

### DIFF
--- a/content/en/guide/supply-chain/for-suppliers/creation-guide/_index.md
+++ b/content/en/guide/supply-chain/for-suppliers/creation-guide/_index.md
@@ -29,46 +29,27 @@ graph TD
       T6["Firmware with an embedded OS<br>(e.g., base stations, routers, OLT/ONT, set-top boxes)"]
     end
 
-    subgraph G3["Commercial finished product (no source code)"]
-      direction LR
-      T7["Commercial packaged software<br>(e.g., reseller / distributor)"]
-      T8["Appliance / finished equipment<br>(e.g., storage, backup appliances)"]
-    end
-
     A --> G1
     A --> G2
-    A --> G3
-
-    G1 --> M1(["Target: source code<br>Tool: cdxgen or BomLens"])
-
-    G2 --> L1(["App layer<br>Target: source code<br>Tool: cdxgen or BomLens"])
-    G2 --> L2(["OS layer<br>Target: shipped image, rootfs<br>Tool: Syft or Trivy"])
-    L1 --> MG["Merge the per-layer SBOMs"]
-    L2 --> MG
-
-    G3 --> M3(["Obtain the SBOM<br>from the manufacturer"])
-
+    G1 --> M1(["Scan the source code<br>cdxgen or BomLens"])
+    G2 --> M2(["Scan source + OS image<br>cdxgen/BomLens + Syft/Trivy"])
     M1 --> P(["Submit the SBOM"])
-    MG --> P
-    M3 --> P
+    M2 --> P
 
     classDef start fill:#F2F2F2,stroke:#171717,color:#171717,stroke-width:1.5px
     classDef typebox fill:#ffffff,stroke:#c8c8c8,color:#171717,stroke-width:1px
     classDef source fill:#D9F0E4,stroke:#00A651,color:#0A5A32,stroke-width:1.5px
     classDef osmerge fill:#EEDCF3,stroke:#68127A,color:#4A0D57,stroke-width:1.5px
-    classDef vendor fill:#FFF3CD,stroke:#E0A800,color:#5A4100,stroke-width:1.5px
     classDef submit fill:#F2F2F2,stroke:#171717,color:#171717,stroke-width:1.5px
 
     class A start
-    class T1,T2,T3,T4,T5,T6,T7,T8 typebox
-    class M1,L1 source
-    class L2,MG osmerge
-    class M3 vendor
+    class T1,T2,T3,T4,T5,T6 typebox
+    class M1 source
+    class M2 osmerge
     class P submit
 
     style G1 fill:#F1FAF5,stroke:#00A651,stroke-width:1px,color:#0A5A32
     style G2 fill:#FAF4FB,stroke:#68127A,stroke-width:1px,color:#4A0D57
-    style G3 fill:#FFF9E8,stroke:#E0A800,stroke-width:1px,color:#5A4100
 ```
 
 For software you developed yourself, scan the source code to produce the SBOM regardless of the delivery form. Even when you deliver an executable, a binary, or firmware, scan the source code that produced it, not the finished artifact. Scanning a finished binary directly yields no package manager metadata, so PURLs are omitted, vulnerability matching fails entirely, and the SBOM is rejected.

--- a/content/ko/guide/supply-chain/for-suppliers/creation-guide/_index.md
+++ b/content/ko/guide/supply-chain/for-suppliers/creation-guide/_index.md
@@ -29,46 +29,27 @@ graph TD
       T6["OS 내장 펌웨어<br>(예: 기지국, 라우터, OLT/ONT, 셋톱박스)"]
     end
 
-    subgraph G3["상용 완제품 공급 (소스코드 없음)"]
-      direction LR
-      T7["상용 패키지 소프트웨어<br>(예: 리셀러·총판 공급)"]
-      T8["어플라이언스·완제품 장비<br>(예: 스토리지, 백업 장비)"]
-    end
-
     A --> G1
     A --> G2
-    A --> G3
-
-    G1 --> M1(["대상: 소스코드<br>도구: cdxgen 또는 BomLens"])
-
-    G2 --> L1(["앱 층<br>대상: 소스코드<br>도구: cdxgen 또는 BomLens"])
-    G2 --> L2(["OS 층<br>대상: 납품 이미지, rootfs<br>도구: Syft 또는 Trivy"])
-    L1 --> MG["층별 SBOM 병합"]
-    L2 --> MG
-
-    G3 --> M3(["제조사 SBOM 수령"])
-
+    G1 --> M1(["소스코드 스캔<br>cdxgen 또는 BomLens"])
+    G2 --> M2(["소스코드 + OS 이미지 스캔<br>cdxgen/BomLens + Syft/Trivy"])
     M1 --> P(["SBOM 제출"])
-    MG --> P
-    M3 --> P
+    M2 --> P
 
     classDef start fill:#F2F2F2,stroke:#171717,color:#171717,stroke-width:1.5px
     classDef typebox fill:#ffffff,stroke:#c8c8c8,color:#171717,stroke-width:1px
     classDef source fill:#D9F0E4,stroke:#00A651,color:#0A5A32,stroke-width:1.5px
     classDef osmerge fill:#EEDCF3,stroke:#68127A,color:#4A0D57,stroke-width:1.5px
-    classDef vendor fill:#FFF3CD,stroke:#E0A800,color:#5A4100,stroke-width:1.5px
     classDef submit fill:#F2F2F2,stroke:#171717,color:#171717,stroke-width:1.5px
 
     class A start
-    class T1,T2,T3,T4,T5,T6,T7,T8 typebox
-    class M1,L1 source
-    class L2,MG osmerge
-    class M3 vendor
+    class T1,T2,T3,T4,T5,T6 typebox
+    class M1 source
+    class M2 osmerge
     class P submit
 
     style G1 fill:#F1FAF5,stroke:#00A651,stroke-width:1px,color:#0A5A32
     style G2 fill:#FAF4FB,stroke:#68127A,stroke-width:1px,color:#4A0D57
-    style G3 fill:#FFF9E8,stroke:#E0A800,stroke-width:1px,color:#5A4100
 ```
 
 자체 개발 소프트웨어라면 납품 형태와 무관하게 자기가 개발한 소스코드를 스캔해 SBOM을 만듭니다. 실행 파일이나 바이너리, 펌웨어로 납품하더라도 완성된 산출물이 아니라 그것을 만든 소스코드를 스캔합니다. 완성된 바이너리를 그대로 스캔하면 패키지 매니저 메타데이터가 없어 purl이 누락되고, 취약점 매칭이 전량 실패해 반려됩니다.


### PR DESCRIPTION
PR #258에서 변경한 도구 선택 가이드 다이어그램(creation-guide, ko/en)을 원래 레이아웃으로 되돌립니다. 본문 텍스트 보완(자체 개발 표현, 상용 소프트웨어 공급 안내 문단)과 상용 소프트웨어 공급 페이지는 그대로 유지합니다.