### PR TITLE
fix(ai-sbom): the AI compliance profile no longer has a sample page

### DIFF
--- a/content/en/guide/release/ai-model/ai-sbom/_index.md
+++ b/content/en/guide/release/ai-model/ai-sbom/_index.md
@@ -122,10 +122,10 @@ move the verdict. Read the covered count and the gap count separately.
 
 - Gaps come in two kinds: those you close by writing in the model card, and those a person has to
   judge. Start with the first kind.
-- To see what the reports look like before running anything, open the
+- To see what a report looks like before running anything, open the
   [conformance report](https://sktelecom.github.io/bomlens/samples/aether-7b-5attn_conformance.html)
-  and the [AI compliance profile](https://sktelecom.github.io/bomlens/samples/aether-7b-5attn_ai-profile.html)
-  from a sample model scan.
+  from a sample model scan. It opens with coverage per cluster and the licences flagged for review,
+  then works down to the per-check verdicts.
 
 ## Related pages
 

--- a/content/ko/guide/release/ai-model/ai-sbom/_index.md
+++ b/content/ko/guide/release/ai-model/ai-sbom/_index.md
@@ -118,9 +118,9 @@ SK텔레콤이 공개한 오픈소스인 [BomLens](https://github.com/sktelecom/
 - 비어 있는 항목은 두 종류로 나뉩니다. 모델 카드에 쓰면 채워지는 것과, 사람이 판단해야 하는
   것입니다. 앞의 것부터 메우시면 됩니다.
 - 보고서가 실제로 어떤 모습인지는 예시로 미리 볼 수 있습니다. 예시 모델을 스캔해 나온
-  [적합성 보고서](https://sktelecom.github.io/bomlens/ko/samples/aether-7b-5attn_conformance.html)와
-  [AI 준수 개요](https://sktelecom.github.io/bomlens/ko/samples/aether-7b-5attn_ai-profile.html)를
-  브라우저에서 그대로 열어 볼 수 있습니다.
+  [적합성 보고서](https://sktelecom.github.io/bomlens/ko/samples/aether-7b-5attn_conformance.html)를
+  브라우저에서 그대로 열어 볼 수 있습니다. 묶음별 충족 현황과 검토 대상 라이선스가 맨 위에,
+  항목별 판정이 그 아래에 나옵니다.
 
 ## 관련 문서
 


### PR DESCRIPTION
BomLens folded the AI compliance profile's rollup into the conformance report and stopped writing a separate HTML profile, so the sample this page linked returns 404. Both language versions now link the conformance report only, and the sentence says what that report opens with.