### PR TITLE
Add A.X K2 to A.X LLM project page

### DIFF
--- a/content/en/project/axllm/_index.md
+++ b/content/en/project/axllm/_index.md
@@ -11,22 +11,34 @@ description: >
 
 ![A.X LLM](A.X_logo.png)
 
-A.X LLM is a series of Korean-specialized large language models independently developed by SK Telecom. A.X K1, A.X 4.0, and A.X 3.1 are publicly available as open source and can be freely used for academic research and commercial purposes.
+A.X LLM is a series of Korean-specialized large language models independently developed by SK Telecom. A.X K2, A.X K1, A.X 4.0, and A.X 3.1 are publicly available as open source and can be freely used for academic research and commercial purposes.
 
 ## Project Information
 
 * Developer: SK Telecom
 * License: Apache-2.0
 * GitHub: 
+  - [A.X K2](https://github.com/SKT-AI/A.X-K2)
   - [A.X K1](https://github.com/SKT-AI/A.X-K1)
   - [A.X 4.0](https://github.com/SKT-AI/A.X-4.0)
   - [A.X 3.1](https://github.com/SKT-AI/A.X-3)
   - [A.X 4.0-VL-Light](https://github.com/SKT-AI/A.X-4.0-VL-Light)
 * Hugging Face:
+  - [A.X K2 Collection](https://huggingface.co/collections/skt/ax-k2)
+  - [A.X K2](https://huggingface.co/skt/A.X-K2)
   - [A.X K1](https://huggingface.co/skt/A.X-K1)
   - [SKT-AI Organization](https://huggingface.co/skt)
 
 ## Key Features
+
+### A.X K2 Series
+* 688B-A33B Sparse MoE: A large-scale Mixture-of-Experts model with 688B total parameters and 33B active parameters per token
+* Mathematical and scientific reasoning: Scored 29/42 on IMO 2026, reaching the gold-medal threshold, and tied for the top score on the MathArena AIME 2026 leaderboard with 97.1%
+* Sparse Gated Attention (SGA): Selects the most relevant information in long contexts to improve accuracy and inference efficiency
+* Long-context support: Supports a 262,144-token (256K) context length
+* Native FP8 training and FP8 checkpoint: Enables efficient FP8 serving without a separate post-hoc quantization step
+* Deployment checkpoints: Provides GGUF and NVFP4 quantized builds together with EAGLE3 and DSpark draft models for faster inference
+* Multimodal derivative lineup: Also publishes model cards and technical materials for A.X VE, a vision encoder trained from scratch, and A.X K2 ALM, an audio language model for speech understanding and generation
 
 ### A.X K1 Series
 * 519B-A33B Sparse MoE: A large-scale Mixture-of-Experts model with 519B total parameters and 33B active parameters per token
@@ -58,6 +70,7 @@ A.X LLM is a series of Korean-specialized large language models independently de
 - Optimized for Korean business environments
 
 ### Model Architecture
+- A.X K2: A from-scratch 688B-A33B proprietary Sparse MoE model
 - A.X K1: A from-scratch 519B-A33B proprietary Sparse MoE model
 - A.X 3 series: Sovereign AI developed from scratch
 - A.X 4 series: Open-source models enhanced with CPT (Continual Pre-Training) using large-scale Korean data
@@ -78,19 +91,25 @@ A.X LLM is a series of Korean-specialized large language models independently de
 
 ## Benchmark Performance
 
-| Model | Parameters | KMMLU Score | Features |
-|-------|-----------|-------------|----------|
-| A.X K1 | 519B-A33B | 80.2 (Thinking Mode) | Sparse MoE, long context |
-| A.X 4.0 | 72B | 78.3 | High performance |
-| A.X 3.1 | 34B | 69.2 | Independently developed |
+| Model | Parameters | Representative Score | Features |
+|-------|-----------|----------------------|----------|
+| A.X K2 | 688B-A33B | IMO 2026 29/42 (gold-medal threshold) / AIME 2026 97.1 | SGA, 256K context |
+| A.X K1 | 519B-A33B | KMMLU 80.2 (Thinking Mode) | Sparse MoE, long context |
+| A.X 4.0 | 72B | KMMLU 78.3 | High performance |
+| A.X 3.1 | 34B | KMMLU 69.2 | Independently developed |
 | A.X 4.0 Light | 7B | - | Efficiency |
 | A.X 3.1 Light | - | - | Lightweight |
 
 ## Resources
 
+* A.X K2: [GitHub](https://github.com/SKT-AI/A.X-K2) / [Hugging Face](https://huggingface.co/skt/A.X-K2) / [Collection](https://huggingface.co/collections/skt/ax-k2)
+* A.X K2 deployment checkpoints: [GGUF](https://huggingface.co/skt/A.X-K2-GGUF) / [NVFP4](https://huggingface.co/skt/A.X-K2-NVFP4) / [EAGLE3](https://huggingface.co/skt/A.X-K2-EAGLE3) / [DSpark](https://huggingface.co/skt/A.X-K2-DSpark)
+* A.X K2 multimodal lineup: [A.X VE](https://huggingface.co/skt/A.X-VE) / [A.X K2 ALM](https://huggingface.co/skt/A.X-K2-ALM)
+* A.X K2 Technical Report: [GitHub](https://github.com/SKT-AI/A.X-K2/blob/main/A_X_K2_Tech_Report.pdf)
 * A.X K1: [GitHub](https://github.com/SKT-AI/A.X-K1) / [Hugging Face](https://huggingface.co/skt/A.X-K1)
 * A.X K1 Technical Report: [arXiv:2601.09200](https://arxiv.org/abs/2601.09200)
 * Hugging Face: [SKT-AI Organization](https://huggingface.co/skt)
 * GitHub: [SKT-AI](https://github.com/SKT-AI)
+* Related press releases: [Mathematical reasoning performance](https://news.sktelecom.com/229153) / [A.X K2 announcement](https://news.sktelecom.com/en/3204) / [Sovereign AI Phase 2](https://news.sktelecom.com/en/2593)
 * Official News: [SK Telecom Newsroom](https://news.sktelecom.com/217916)
 * Contact: [a.x@sk.com](mailto:a.x@sk.com)

--- a/content/ko/project/axllm/_index.md
+++ b/content/ko/project/axllm/_index.md
@@ -12,7 +12,7 @@ description: >
 
 ![A.X LLM](A.X_logo.png)
 
-A.X LLM은 SK텔레콤이 독자 개발한 한국어 특화 대규모 언어 모델(Large Language Model)입니다. A.X K1, A.X 4.0, A.X 3.1 시리즈가 오픈소스로 공개되어 있으며, 학술 연구 및 상업적 용도로 자유롭게 사용할 수 있습니다.
+A.X LLM은 SK텔레콤이 독자 개발한 한국어 특화 대규모 언어 모델(Large Language Model)입니다. A.X K2, A.X K1, A.X 4.0, A.X 3.1 시리즈가 오픈소스로 공개되어 있으며, 학술 연구 및 상업적 용도로 자유롭게 사용할 수 있습니다.
 
 
 ## 프로젝트 정보
@@ -20,15 +20,27 @@ A.X LLM은 SK텔레콤이 독자 개발한 한국어 특화 대규모 언어 모
 * 개발: SK텔레콤
 * 라이선스: Apache-2.0
 * GitHub: 
+  - [A.X K2](https://github.com/SKT-AI/A.X-K2)
   - [A.X K1](https://github.com/SKT-AI/A.X-K1)
   - [A.X 4.0](https://github.com/SKT-AI/A.X-4.0)
   - [A.X 3.1](https://github.com/SKT-AI/A.X-3)
   - [A.X 4.0-VL-Light](https://github.com/SKT-AI/A.X-4.0-VL-Light)
 * Hugging Face:
+  - [A.X K2 Collection](https://huggingface.co/collections/skt/ax-k2)
+  - [A.X K2](https://huggingface.co/skt/A.X-K2)
   - [A.X K1](https://huggingface.co/skt/A.X-K1)
   - [SKT-AI Organization](https://huggingface.co/skt)
 
 ## 주요 특징
+
+### A.X K2 시리즈
+* 688B-A33B Sparse MoE: 총 688B 파라미터 중 토큰당 33B 파라미터가 활성화되는 대규모 Mixture-of-Experts 모델
+* 수학·과학 추론 강화: IMO 2026에서 29/42점으로 금메달 기준에 도달하고, MathArena AIME 2026 리더보드에서 97.1%로 공동 최고점 달성
+* Sparse Gated Attention(SGA): 긴 문맥에서 관련성이 높은 정보를 선별해 정확성과 추론 효율 향상
+* 긴 컨텍스트 처리: 262,144 토큰(256K) 컨텍스트 길이를 지원
+* Native FP8 학습 및 FP8 체크포인트: 별도 사후 양자화 없이 효율적인 FP8 서빙을 지원
+* 배포용 체크포인트 공개: GGUF와 NVFP4 양자화 빌드, EAGLE3와 DSpark 고속 추론용 draft 모델을 함께 제공
+* 멀티모달 파생 라인업: 독자 기술로 학습한 Vision Encoder(A.X VE)와 음성 이해·생성을 위한 Audio Language Model(A.X K2 ALM)의 모델 카드와 기술 자료도 함께 공개
 
 ### A.X K1 시리즈
 * 519B-A33B Sparse MoE: 총 519B 파라미터 중 토큰당 33B 파라미터가 활성화되는 대규모 Mixture-of-Experts 모델
@@ -60,6 +72,7 @@ A.X LLM은 SK텔레콤이 독자 개발한 한국어 특화 대규모 언어 모
 - 한국 비즈니스 환경에 최적화
 
 ### 모델 아키텍처
+- A.X K2: from-scratch 학습한 688B-A33B 독자 구조 Sparse MoE 모델
 - A.X K1: from-scratch 학습한 519B-A33B 독자 구조 Sparse MoE 모델
 - A.X 3 시리즈: 처음부터 독자 개발한 sovereign AI
 - A.X 4 시리즈: 오픈소스 모델에 대규모 한국어 데이터로 CPT(Continual Pre-Training) 적용
@@ -80,19 +93,25 @@ A.X LLM은 SK텔레콤이 독자 개발한 한국어 특화 대규모 언어 모
 
 ## 벤치마크 성능
 
-| 모델 | 파라미터 수 | KMMLU 점수 | 특징 |
+| 모델 | 파라미터 수 | 대표 성능 | 특징 |
 |------|------------|-----------|------|
-| A.X K1 | 519B-A33B | 80.2 (Thinking Mode) | Sparse MoE, 긴 컨텍스트 |
-| A.X 4.0 | 72B | 78.3 | 우수 성능 |
-| A.X 3.1 | 34B | 69.2 | 독자 개발 |
+| A.X K2 | 688B-A33B | IMO 2026 29/42 (금메달 기준) / AIME 2026 97.1 | SGA, 256K 컨텍스트 |
+| A.X K1 | 519B-A33B | KMMLU 80.2 (Thinking Mode) | Sparse MoE, 긴 컨텍스트 |
+| A.X 4.0 | 72B | KMMLU 78.3 | 우수 성능 |
+| A.X 3.1 | 34B | KMMLU 69.2 | 독자 개발 |
 | A.X 4.0 Light | 7B | - | 효율성 |
 | A.X 3.1 Light | - | - | 경량화 |
 
 ## 리소스
 
+* A.X K2: [GitHub](https://github.com/SKT-AI/A.X-K2) / [Hugging Face](https://huggingface.co/skt/A.X-K2) / [Collection](https://huggingface.co/collections/skt/ax-k2)
+* A.X K2 배포용 체크포인트: [GGUF](https://huggingface.co/skt/A.X-K2-GGUF) / [NVFP4](https://huggingface.co/skt/A.X-K2-NVFP4) / [EAGLE3](https://huggingface.co/skt/A.X-K2-EAGLE3) / [DSpark](https://huggingface.co/skt/A.X-K2-DSpark)
+* A.X K2 멀티모달 라인업: [A.X VE](https://huggingface.co/skt/A.X-VE) / [A.X K2 ALM](https://huggingface.co/skt/A.X-K2-ALM)
+* A.X K2 Technical Report: [GitHub](https://github.com/SKT-AI/A.X-K2/blob/main/A_X_K2_Tech_Report.pdf)
 * A.X K1: [GitHub](https://github.com/SKT-AI/A.X-K1) / [Hugging Face](https://huggingface.co/skt/A.X-K1)
 * A.X K1 Technical Report: [arXiv:2601.09200](https://arxiv.org/abs/2601.09200)
 * Hugging Face: [SKT-AI Organization](https://huggingface.co/skt)
 * GitHub: [SKT-AI](https://github.com/SKT-AI)
+* 관련 보도자료: [수학 추론 성능](https://news.sktelecom.com/229153) / [A.X K2 공개](https://news.sktelecom.com/228501) / [선행연구 세미나](https://news.sktelecom.com/226835) / [참여사 확대](https://news.sktelecom.com/227799) / [제조 현장 적용](https://news.sktelecom.com/227025) / [엔비디아 협력](https://news.sktelecom.com/224081)
 * 공식 뉴스: [SK텔레콤 뉴스룸](https://news.sktelecom.com/217916)
 * 문의: a.x@sk.com


### PR DESCRIPTION
## Summary
- Add A.X K2 to the A.X LLM project page
- Update Korean and English pages with GitHub, Hugging Face, collection, and news links
- Add K2 model summary, IMO 2026/AIME 2026 math reasoning performance, deployment checkpoints, and multimodal derivative lineup

## Approval
- Team lead approval received

## Validation
- `npm run build` passed
- `git diff --check` passed