### PR TITLE
style(alert): alert 박스 좌측 색상 강조선 제거

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -788,20 +788,15 @@ a.skt-card:hover,
   padding-bottom: 4rem;
 }
 
-/* alert/callout — KWG식 좌측 보더 + 연배경. 박스·본문은 무채색, 종류 구분은 좌측 보더색.
+/* alert/callout — 박스·본문은 무채색, 테두리는 전체 균일(좌측 강조선 없음).
    HTML 구조: .alert > .alert-heading(.h4) + p/ul  (Docsy alert 숏코드) */
 .alert {
   padding: 1rem 1.25rem;
   background: var(--skt-surface-subtle);
   border: 1px solid var(--skt-border);
-  border-left: 3px solid var(--skt-accent);   /* 좌측 보더 = SK Red 액센트(다크 자동 보정) */
   border-radius: $border-radius-lg;
   color: var(--skt-text);
 }
-/* 종류 구분은 좌측 보더색으로(아이콘 대체). info/기본은 무채색 유지 */
-.alert-warning { border-left-color: #{$skt-orange}; }
-.alert-danger  { border-left-color: #{$skt-red}; }
-.alert-success { border-left-color: #{$skt-green}; }
 .alert .alert-heading {
   font-size: 1rem;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- alert/callout 박스의 좌측 색상 보더(SK Red/Orange/Green)를 제거하고 무채색 테두리로 통일
- 사이트 전역 alert 사용처(90여개 문서)에 공통 적용

## Test plan
- [x] `npm run build` 통과
- [x] 로컬 렌더링으로 기본/경고(warning) 유형 박스 확인 — 좌측 색선 없이 균일한 테두리