### PR TITLE
chore(deps): ignore FontAwesome major updates until Docsy supports them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,13 @@ updates:
       interval: daily
       time: '20:00'
     open-pull-requests-limit: 10
+    ignore:
+      # FontAwesome 7은 SCSS를 Dart Sass 모듈 문법으로 다시 써서
+      # Hugo의 libsass가 컴파일하지 못하고, 개별 $fa-var-* 변수도 없앴다.
+      # Docsy가 그 변수들을 참조하므로 사이트 빌드가 깨진다(PR #294).
+      # Docsy가 FontAwesome 7을 지원하면 이 항목을 지운다.
+      - dependency-name: '@fortawesome/fontawesome-free'
+        update-types: ['version-update:semver-major']
   - package-ecosystem: bundler
     directory: '/'
     schedule:


### PR DESCRIPTION
FontAwesome의 메이저 버전 업데이트를 Dependabot 대상에서 제외합니다.

## 배경

Dependabot이 올린 #294(6.7.2 → 7.3.1)를 검증한 결과, 머지하면 사이트 빌드가 실패합니다. PR 브랜치에 master를 합쳐 실제 머지 결과와 같은 상태로 빌드해 확인했습니다.

```
TOCSS: failed to transform "/scss/main.scss" (text/x-scss):
node_modules/@fortawesome/fontawesome-free/scss/solid.scss:11:39:
Invalid CSS after "  --#{v": expected expression (e.g. 1px, bold), was ".\$css-prefix}-famil"
```

원인은 두 가지입니다.

FontAwesome 7이 SCSS를 Dart Sass 모듈 문법으로 다시 썼습니다. `@use "sass:string"`과 `--#{v.\$css-prefix}-family` 같은 커스텀 속성 보간을 쓰는데, Hugo가 SCSS 변환에 사용하는 libsass는 이 문법을 처리하지 못합니다.

그리고 개별 아이콘 변수가 없어졌습니다. FontAwesome 6의 `_variables.scss`에 있던 `\$fa-var-xmark`, `\$fa-var-search` 등이 7에는 하나도 없고 `\$icons` 맵으로 대체됐습니다. Docsy 0.16.0은 이 변수들을 직접 참조합니다. Docsy 자신도 `package.json`에서 `@fortawesome/fontawesome-free`를 6.7.2로 고정하고 있습니다.

## 변경 내용

npm 생태계 설정에 `ignore` 항목을 추가해 `@fortawesome/fontawesome-free`의 메이저 업데이트만 제외했습니다. 패치와 마이너 업데이트는 그대로 추적합니다.

Docsy가 FontAwesome 7을 지원하는 버전으로 올라가면 이 규칙을 지우고 다시 올립니다. 그 조건을 설정 파일 주석에 남겨 두었습니다.

#294는 이 이유로 닫습니다.